### PR TITLE
repo clone: use github token instead of password

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -12,6 +12,9 @@ project_file: ~/.config/wdk/project.yml
 
 cache_dir: ~/.local/cache/wdk
 
+# Your GitHub credentials. The token needs only read access.
+github_username: john
+github_token: 123456789abcdef0123456789abcdef012345678
 # The GitHub organisations to clone from
 github_orgs:
   - wazo-platform

--- a/wazo_sdk/commands/repo_clone.py
+++ b/wazo_sdk/commands/repo_clone.py
@@ -5,7 +5,6 @@ import logging
 import os
 
 from cliff.command import Command
-from getpass import getpass
 from git import Repo
 from github3 import login
 
@@ -16,11 +15,15 @@ class RepoClone(Command):
         if not self.config.github_orgs:
             self.app.LOG.error('No GitHub organisations configured')
             return
+        if not self.config.github_username:
+            self.app.LOG.error('No GitHub username configured')
+            return
+        if not self.config.github_token:
+            self.app.LOG.error('No GitHub personal access token configured')
+            return
 
-        user = getpass('GitHub user: ')
-        password = getpass('GitHub password for {0}: '.format(user))
         logging.getLogger('github3').setLevel(logging.WARNING)
-        github = login(user, password)
+        github = login(self.config.github_username, self.config.github_token)
         for org_name in self.config.github_orgs:
             for repo in github.organization(org_name).repositories():
                 self.app.LOG.info('Cloning %s...', repo.name)

--- a/wazo_sdk/config.py
+++ b/wazo_sdk/config.py
@@ -52,6 +52,14 @@ class Config:
     def github_orgs(self):
         return self._file_config.get('github_orgs')
 
+    @property
+    def github_token(self):
+        return self._file_config.get('github_token')
+
+    @property
+    def github_username(self):
+        return self._file_config.get('github_username')
+
     def get_project(self, short_name):
         name = self.get_project_name(short_name)
         return self._project_config[name]


### PR DESCRIPTION
Why:

* Github is deprecating the usage of passwords in favor of personal
access tokens