### PR TITLE
mount: exclude tox directory

### DIFF
--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -16,7 +16,7 @@ sync {
     delay = 1,
     source = "{{ source }}",
     target = "{{ host }}:{{ destination }}",
-    exclude = {'.git'},
+    exclude = {'.git', '.tox'},
     rsync = {
         xattrs = true,
         archive = true,


### PR DESCRIPTION
Why:

* tox directory is usually 10x larger than the code. It takes a lot of
unwanted extra space and make the mount longer because the files to
synchronize are larger.