### PR TITLE
avoid to sync node_modules directory

### DIFF
--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 import psutil
@@ -16,7 +16,7 @@ sync {
     delay = 1,
     source = "{{ source }}",
     target = "{{ host }}:{{ destination }}",
-    exclude = {'.git', '.tox'},
+    exclude = {'.git', '.tox', 'node_modules'},
     rsync = {
         xattrs = true,
         archive = true,


### PR DESCRIPTION
reason: useless to sync all dependencies
You usually compile on your host OR dev, not both