### PR TITLE
[WAZO-1845] Add rsync only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 Developer tool kit for Wazo development
 
-
 ## Installation
 
 `wdk` depends on lsyncd. It can be installed on a Debian or Ubuntu with the following
 commands. If you running on macOS, lsyncd won't work, so you must set `rsync_only` option to `true`.
 
 ### Installing WDK
+
 The recommended way to install `wdk` is to use a virtual environment.
 
 #### Debian Instructions
+
 ```sh
 sudo apt update
 sudo apt install lsyncd virtualenvwrapper python3-dev
@@ -20,6 +21,7 @@ mkvirtualenv --python /usr/bin/python3 wdk
 ```
 
 #### macOS Instructions
+
 ```sh
 brew install rsync # install latest
 brew install python # install python3
@@ -31,6 +33,7 @@ source ~/.virtualenvs/wdk/bin/activate
 ```
 
 #### WDK Dependencies
+
 ```sh
 pip install -r requirements.txt
 pip install -e .
@@ -56,7 +59,6 @@ apt install rsync
 mkdir /usr/src/wazo  # or whatever your <local_source>
 ```
 
-
 ## Configuration
 
 The default location of the configuration file is `~/.config/wdk/config.yml` you can check
@@ -64,7 +66,6 @@ The default location of the configuration file is `~/.config/wdk/config.yml` you
 
 If you wish to use another location for you configuration file you can use the `--config` flag
 when launching `wdk` or set the `WDK_CONFIG_FILE` environment variable to the config file location.
-
 
 ### Project configuration
 
@@ -97,7 +98,6 @@ file.
 
 Note that new entry points will need the project to be unmounted and mounted again to be applied.
 
-
 ## Mounting a project
 
 ```sh
@@ -127,6 +127,7 @@ wdk restart [<project1>, <project2>]
 ```sh
 wdk repo clone
 ```
+
 `wdk` will ask for your login/password and clone every repo of the GitHub orgs listed in the config.
 
 ## Tailing a log files
@@ -162,7 +163,7 @@ lsyncd -nodaemon -delay 1 -rsyncssh /home/user/git/origin/wazo-confd wazo.exampl
 
 * `echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
 
-For more information: https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers
+For more information: <https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers>
 
 ## The state file
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,32 @@ Developer tool kit for Wazo development
 ## Installation
 
 `wdk` depends on lsyncd. It can be installed on a Debian or Ubuntu with the following
-commands
+commands. If you running on macOS, lsyncd won't work, so you must set `rsync_only` option to `true`.
 
+### Installing WDK
+The recommended way to install `wdk` is to use a virtual environment.
+
+#### Debian Instructions
 ```sh
 sudo apt update
 sudo apt install lsyncd virtualenvwrapper python3-dev
-```
-
-The recommended way to install `wdk` is to use a virtual environment.
-
-```sh
 source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
 mkvirtualenv --python /usr/bin/python3 wdk
+```
+
+#### macOS Instructions
+```sh
+brew install rsync # install latest
+brew install python # install python3
+# Reload your terminal session to have the latest rsync
+pip install --user virtualenvwrapper
+mkdir -p ~/.virtualenvs
+virtualenv -p python3 ~/.virtualenvs/wdk
+source ~/.virtualenvs/wdk/bin/activate
+```
+
+#### WDK Dependencies
+```sh
 pip install -r requirements.txt
 pip install -e .
 sudo ln -s ~/.virtualenvs/wdk/bin/wdk /usr/local/bin/wdk
@@ -33,7 +47,6 @@ mkdir -p ~/.config/wdk
 cp config.yml.sample ~/.config/wdk/config.yml
 ln -s $(readlink -f project.yml) ~/.config/wdk/project.yml
 ```
-
 
 ### On the target machine (Wazo)
 

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -12,6 +12,8 @@ project_file: ~/.config/wdk/project.yml
 
 cache_dir: ~/.local/cache/wdk
 
+rsyncOnly: false
+
 # Your GitHub credentials. The token needs only read access.
 github_username: john
 github_token: 123456789abcdef0123456789abcdef012345678

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -12,7 +12,7 @@ project_file: ~/.config/wdk/project.yml
 
 cache_dir: ~/.local/cache/wdk
 
-rsyncOnly: false
+rsync_only: false
 
 # Your GitHub credentials. The token needs only read access.
 github_username: john

--- a/wazo_sdk/config.py
+++ b/wazo_sdk/config.py
@@ -27,7 +27,7 @@ class Config:
 
     @property
     def rsyncOnly(self):
-        return self._args.rsync_only or False
+        return self._args.rsync_only or self._file_config.get('rsyncOnly') or False
 
     @property
     def local_source(self):

--- a/wazo_sdk/config.py
+++ b/wazo_sdk/config.py
@@ -26,6 +26,10 @@ class Config:
         return self._args.hostname or self._file_config.get('hostname')
 
     @property
+    def rsyncOnly(self):
+        return self._args.rsync_only or False
+
+    @property
     def local_source(self):
         return os.path.expanduser(
             self._args.dev_dir or self._file_config.get('local_source')

--- a/wazo_sdk/config.py
+++ b/wazo_sdk/config.py
@@ -26,8 +26,8 @@ class Config:
         return self._args.hostname or self._file_config.get('hostname')
 
     @property
-    def rsyncOnly(self):
-        return self._args.rsync_only or self._file_config.get('rsyncOnly') or False
+    def rsync_only(self):
+        return self._args.rsync_only or self._file_config.get('rsync_only') or False
 
     @property
     def local_source(self):

--- a/wazo_sdk/main.py
+++ b/wazo_sdk/main.py
@@ -34,6 +34,8 @@ class WDK(App):
         parser.add_argument('--project-file', help='Project configuration file', default=None)
         parser.add_argument('--hostname', help='The remote host when Wazo is installed')
         parser.add_argument('--dev-dir', help='Where the local source code is')
+        parser.add_argument('--rsync-only', action='store_true', help='Use rsync only to mount/unmount respositories', default=False)
+
         return parser
 
     def initialize_app(self, argv):

--- a/wazo_sdk/main.py
+++ b/wazo_sdk/main.py
@@ -34,7 +34,7 @@ class WDK(App):
         parser.add_argument('--project-file', help='Project configuration file', default=None)
         parser.add_argument('--hostname', help='The remote host when Wazo is installed')
         parser.add_argument('--dev-dir', help='Where the local source code is')
-        parser.add_argument('--rsync-only', action='store_true', help='Use rsync only to mount/unmount respositories', default=False)
+        parser.add_argument('--rsync-only', action='store_true', help='Use rsync only to mount/unmount respositories')
 
         return parser
 

--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -222,6 +222,7 @@ class Mounter:
             sync_command = ['rsync', *RSYNC_OPTIONS, local_path+'/', self._hostname+":"+remote_path+'/']
             config_filename = None
             pid_filename = None
+            communicate_kwargs = {}
         else:
             config = LSYNC_CONFIG_TEMPLATE.render(
                 source=local_path, host=self._hostname, destination=remote_path)
@@ -232,12 +233,13 @@ class Mounter:
 
             pid_filename = '{}.pid'.format(config_filename)
             sync_command = ['lsyncd', config_filename, '--pidfile', pid_filename]
+            communicate_kwargs = {'timeout': 1}
 
         # Run sync command
         self.logger.debug('%s', ' '.join(sync_command))
         proc = subprocess.Popen(sync_command)
         try:
-            outs, errs = proc.communicate(timeout=1)
+            outs, errs = proc.communicate(**communicate_kwargs)
             if errs:
                 self.logger.info('%s failed %s', ' '.join(sync_command), errs)
                 return

--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -54,7 +54,7 @@ class Mounter:
             yield mount['project'], self._is_sync_running(mount)
 
     def _is_sync_running(self, mount):
-        if self._config.rsyncOnly:
+        if self._config.rsync_only:
             return True
 
         pid_filename = mount['lsync_pidfile']
@@ -95,7 +95,7 @@ class Mounter:
         real_repo_name = self._config.get_project_name(repo_name)
 
         # Skip this condition if we are in rsync only mode, because files a not synced automatically
-        if not self._config.rsyncOnly and self._is_mounted_and_running(real_repo_name):
+        if not self._config.rsync_only and self._is_mounted_and_running(real_repo_name):
             self.logger.debug('%s is already mounted', real_repo_name)
         else:
             self._start_sync(local_repo_name, real_repo_name)
@@ -218,7 +218,7 @@ class Mounter:
         local_path = os.path.join(self._local_dir, local_repo_name)
         remote_path = os.path.join(self._remote_dir, real_repo_name)
 
-        if self._config.rsyncOnly:
+        if self._config.rsync_only:
             sync_command = ['rsync', *RSYNC_OPTIONS, local_path+'/', self._hostname+":"+remote_path+'/']
             config_filename = None
             pid_filename = None
@@ -250,7 +250,7 @@ class Mounter:
         self._state.add_mount(self._hostname, real_repo_name, config_filename, pid_filename)
 
     def _stop_sync(self, repo_name):
-        if self._config.rsyncOnly:
+        if self._config.rsync_only:
             return
 
         mount = self._state.get_mount(self._hostname, repo_name)

--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -248,6 +248,9 @@ class Mounter:
         self._state.add_mount(self._hostname, real_repo_name, config_filename, pid_filename)
 
     def _stop_sync(self, repo_name):
+        if self._config.rsyncOnly:
+            return
+
         mount = self._state.get_mount(self._hostname, repo_name)
         if not mount:
             self.logger.error('failed to find a matching mount to stop')

--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -49,9 +49,12 @@ class Mounter:
     def list_(self):
         mounts = self._state.get_mounts(self._hostname)
         for mount in list(mounts.values()):
-            yield mount['project'], self._is_lsync_running(mount)
+            yield mount['project'], self._is_sync_running(mount)
 
-    def _is_lsync_running(self, mount):
+    def _is_sync_running(self, mount):
+        if self._config.rsyncOnly:
+            return True
+
         pid_filename = mount['lsync_pidfile']
         try:
             with open(pid_filename, 'r') as f:
@@ -77,7 +80,7 @@ class Mounter:
         if not mount:
             return False
 
-        return self._is_lsync_running(mount)
+        return self._is_sync_running(mount)
 
     def mount(self, repo_name):
         if not self._hostname:


### PR DESCRIPTION
Improve the compatibility of WDK for macOS. `lsyncd` is not usable on a Mac, this is a minimal work to allow macOS user to use `rsync` only. For sure, later we could find an alternative to `lsyncd` that is cross-platform.