### PR TITLE
WAZO-1552: rename xivo-sysconfd to wazo-sysconfd

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -297,7 +297,7 @@ xivo-swagger-doc:
   bind:
     index.json: /usr/share/xivo-swagger-doc/catalog/index.json
 
-xivo-sysconfd:
+wazo-sysconfd:
   python2: true
 
 xivo-utils:


### PR DESCRIPTION
Relates-To: https://github.com/wazo-platform/xivo-sysconfd/pull/24