### PR TITLE
Init subcommand for installing tools in stack environment

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -24,3 +24,10 @@ github_token: 123456789abcdef0123456789abcdef012345678
 # The GitHub organisations to clone from
 github_orgs:
   - wazo-platform
+
+# configuration affecting the init subcommand
+init:
+  # debian apt packages to install on the remote system when running the init subcommand
+  packages:
+    - rsync
+    - python3-pip

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
             f'{NAME}=wazo_sdk.main:main',
         ],
         'wazo_sdk.commands': [
+            'init = wazo_sdk.commands.init:Init',
             'info = wazo_sdk.commands.info:Info',
             'chores = wazo_sdk.commands.chores_:ChoreList',
             'mount = wazo_sdk.commands.mount:Mount',

--- a/wazo_sdk/commands/init.py
+++ b/wazo_sdk/commands/init.py
@@ -1,0 +1,94 @@
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser, Namespace
+from typing import Any
+
+import sh
+from cliff.app import App
+from cliff.command import Command
+
+from wazo_sdk.config import Config
+
+
+class PackageManager:
+    hostname: str
+
+    def __init__(self, hostname: str, logger: logging.Logger) -> None:
+        self.hostname = hostname
+        self.logger = logger
+
+    def ensure_packages(self, packages: list[str]):
+        if packages:
+            ssh = sh.ssh.bake(self.hostname, _return_cmd=True)
+            self._install_packages(ssh, packages)
+
+            yield from self._check_packages(ssh, packages)
+
+    def _check_packages(self, ssh: sh.Command, packages: list[str]):
+        for pkg in packages:
+            run_cmd: sh.RunningCommand = ssh(f'apt-cache policy {pkg}')
+            # try:
+            # except sh.ErrorReturnCode as ex:
+            #     success = False
+            self.logger.debug('cmd=%s', run_cmd)
+
+            yield {
+                'success': (
+                    run_cmd.exit_code == 0 and pkg in run_cmd.stdout.decode('utf-8')
+                ),
+                'details': run_cmd.stdout.decode('utf-8'),
+                'name': pkg,
+            }
+
+    def _install_packages(self, ssh: sh.Command, packages: list[str]) -> None:
+        # setup_path = os.path.join(self._remote_dir, repo_name, 'setup.py')
+        # self._wait_for_file(ssh, setup_path)
+
+        # repo_dir = os.path.join(self._remote_dir, repo_name)
+        cmd = ['apt-get', 'update', '&&', 'apt-get', 'install', '-y', *packages]
+        run_cmd: sh.RunningCommand = ssh(' '.join(cmd))
+        self.logger.debug("install command: %s", run_cmd)
+        self.logger.debug("install command output: %s", run_cmd.stdout)
+        return run_cmd
+
+
+class Init(Command):
+    """Prepare remote target system for wdk integration"""
+
+    # package_manager: PackageManager
+    config: Config
+    logger = logging.getLogger(__name__)
+    app: App
+
+    def get_parser(self, *args: Any, **kwargs: Any) -> ArgumentParser:
+        parser = super().get_parser(*args, **kwargs)
+        # parser.add_argument(
+        #     '--list', action='store_true', help='list mounted repositories'
+        # )
+        # parser.add_argument(
+        #     '--restart', '-r', action='store_true', help='restart mounted repositories'
+        # )
+        # parser.add_argument(
+        #     'repos', nargs='*', default=[], help='a list repos to mount'
+        # )
+        return parser
+
+    def take_action(self, parsed_args: Namespace) -> None:
+        package_manager = PackageManager(self.config.hostname, self.logger)
+        if not self.config.init_packages:
+            self.app.stdout.write('no packages to install\n')
+            return
+        self.app.stdout.write(
+            f'installing packages in stack environment: {self.config.init_packages}\n'
+        )
+        for pkg in package_manager.ensure_packages(self.config.init_packages):
+            if pkg['success']:
+                self.app.stdout.write(f'package {pkg["name"]} successfully installed\n')
+                if self.app.options.verbose_level > 1 or self.app.options.debug:
+                    self.app.stderr.write(pkg['details'] + '\n')
+            else:
+                self.app.stdout.write(f'package {pkg["name"]} installation failed\n')
+                self.app.stderr.write(pkg["details"] + '\n')

--- a/wazo_sdk/config.py
+++ b/wazo_sdk/config.py
@@ -13,10 +13,13 @@ _DEFAULT_PROJECT_FILENAME = '~/.config/wdk/project.yml'
 _DEFAULT_CACHE_DIR = '~/.local/cache/wdk'
 _DEFAULT_STATE_FILENAME = 'state'
 REPO_PREFIX = ['', 'wazo-', 'xivo-']
-
+DEFAULT_INIT_PACKAGES = ['python3-pip', 'rsync']
 
 if TYPE_CHECKING:
     from typing import TypedDict
+
+    class InitConfigData(TypedDict):
+        packages: list[str]
 
     class ConfigData(TypedDict):
         hostname: str
@@ -29,6 +32,7 @@ if TYPE_CHECKING:
         github_username: str | None
         github_token: str | None
         github_orgs: list[str]
+        init: InitConfigData
 
     class ProjectConfigData(TypedDict):
         python2: bool
@@ -100,6 +104,10 @@ class Config:
     @property
     def github_username(self) -> str | None:
         return self._file_config.get('github_username')
+
+    @property
+    def init_packages(self) -> list[str]:
+        return self._file_config.get('init', {}).get('packages', DEFAULT_INIT_PACKAGES)
 
     def get_project(self, short_name: str) -> ProjectConfigData:
         name = self.get_project_name(short_name)


### PR DESCRIPTION
This adds a subcommand `init` that can install packages on stack remote environment that are useful or required for using wdk or developing with that stack environment.
Currently those packages are installed by default unless the configuration is otherwise:
- `python3-pip`, which is required for editable installs used by the `mount` subcommand
- `rsync`, which is required for the mount subcommand.
  