### PR TITLE
WAZO-2470-remove-hardcoded-asterisk

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -301,7 +301,6 @@ xivo-lib-python:
 xivo-manage-db:
   bind:
     bin/pg-drop-db: /usr/lib/xivo-manage-db/pg-drop-db
-    bin/pg-populate-db: /usr/lib/xivo-manage-db/pg-populate-db
     alembic: /usr/share/xivo-manage-db/alembic
 
 wazo-monitoring:


### PR DESCRIPTION
why: file didn't exist anymore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `bin/pg-populate-db` bind from `xivo-manage-db` in `project.yml` as the file no longer exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6389f5857ce8c03b213dae693d03fd8e7a2ab174. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->