### PR TITLE
project: move dialplan to wazo-asterisk-config

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -44,6 +44,8 @@ wazo-asterisk-cli:
 
 wazo-asterisk-config:
   bind:
+    dialplan: /usr/share/wazo-asterisk-config/dialplan
+    etc/xivo/asterisk/xivo_globals.conf: /etc/xivo/asterisk/xivo_globals.conf
     etc/asterisk/ari.d/01-wazo.conf: /etc/asterisk/ari.d/01-wazo.conf
     etc/asterisk/cel.d/01-wazo.conf: /etc/asterisk/cel.d/01-wazo.conf
     etc/asterisk/manager.d/99-general.conf: /etc/asterisk/manager.d/99-general.conf
@@ -283,8 +285,6 @@ wazo-websocketd:
 
 xivo-config:
   bind:
-    dialplan: /usr/share/xivo-config/dialplan
-    etc/xivo/asterisk/xivo_globals.conf: /etc/xivo/asterisk/xivo_globals.conf
     sbin/xivo-create-config: /usr/sbin/xivo-create-config
     sbin/xivo-read-config: /usr/sbin/xivo-read-config
     sbin/xivo-update-config: /usr/sbin/xivo-update-config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple packaging/bind-mapping change, but it can break deployments if dependent images/scripts still expect these files to come from `xivo-config`.
> 
> **Overview**
> Moves the Asterisk configuration bindings for **dialplan** and `xivo_globals.conf` from `xivo-config` to `wazo-asterisk-config` in `project.yml`, changing which package is responsible for installing those files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 726f39bda378e145b6684866eca35fc24ae0c804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->