### PR TITLE
mount: fix rsync_only unmount

### DIFF
--- a/wazo_sdk/mount.py
+++ b/wazo_sdk/mount.py
@@ -291,14 +291,19 @@ class Mounter:
         )
 
     def _stop_sync(self, repo_name: str) -> None:
-        if self._config.rsync_only:
-            return
-
         mount = self._state.get_mount(self._hostname, repo_name)
         if not mount:
             self.logger.error('failed to find a matching mount to stop')
             return
 
+        self._state.remove_mount(self._hostname, repo_name)
+
+        if self._config.rsync_only:
+            return
+
+        self._stop_lsync(mount)
+
+    def _stop_lsync(self, mount: MountData) -> None:
         pid_filename: str = mount['lsync_pidfile']  # type: ignore
         pid = None
 
@@ -313,8 +318,6 @@ class Mounter:
                 os.kill(pid, signal.SIGTERM)
             except OSError:
                 self.logger.error('failed to kill %s', pid)
-
-        self._state.remove_mount(self._hostname, repo_name)
 
     def _find_local_repo_name(self, repo_name: str) -> str:
         for prefix in REPO_PREFIX:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small control-flow fix in mount teardown with no auth or data-path changes; behavior improves for rsync_only umount.
> 
> **Overview**
> **Fixes `rsync_only` unmount** so SDK mount state is cleared when you umount, instead of returning before updating state.
> 
> `_stop_sync` used to exit immediately when `rsync_only` was set, so **`remove_mount` never ran** and mounts stayed registered. It now **always calls `remove_mount`** after resolving the mount, then skips lsyncd teardown in rsync-only mode.
> 
> lsyncd stop logic is moved to **`_stop_lsync`** and only runs when not in `rsync_only`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db0427ff602e6d1749cf6b2d23feef94537e57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->