### PR TITLE
fix(umount): persist & log through per-repo umount error

### DIFF
--- a/wazo_sdk/commands/mount.py
+++ b/wazo_sdk/commands/mount.py
@@ -1,8 +1,9 @@
-# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from __future__ import annotations
 
+import logging
 from argparse import ArgumentParser, Namespace
 from typing import Any
 
@@ -33,9 +34,13 @@ class Mount(Command):
 
     def take_action(self, parsed_args: Namespace) -> None:
         for repo in parsed_args.repos:
-            self.mounter.mount(repo)
-            if parsed_args.restart:
-                self.service.restart(repo)
+            try:
+                self.mounter.mount(repo)
+            except Exception:
+                self.app.LOG.exception('Error unmount repo %s', repo)
+            else:
+                if parsed_args.restart:
+                    self.service.restart(repo)
 
         if parsed_args.list:
             mounted_repos = self.mounter.list_()
@@ -49,6 +54,7 @@ class Umount(Command):
 
     mounter: Mounter
     service: ServiceManager
+    logger = logging.getLogger(__name__)
 
     def get_parser(self, *args: Any, **kwargs: Any) -> ArgumentParser:
         parser = super().get_parser(*args, **kwargs)
@@ -66,6 +72,10 @@ class Umount(Command):
     def take_action(self, parsed_args: Namespace) -> None:
         repos = parsed_args.repos or [repo for repo, _ in self.mounter.list_()]
         for repo in repos:
-            self.mounter.umount(repo)
-            if parsed_args.restart:
-                self.service.restart(repo)
+            try:
+                self.mounter.umount(repo)
+            except Exception:
+                self.app.LOG.exception('Error unmount repo %s', repo)
+            else:
+                if parsed_args.restart:
+                    self.service.restart(repo)


### PR DESCRIPTION
to give a chance to all repos to unmount

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI error-handling only; failures are logged instead of stopping the loop, with no auth or data-path changes.
> 
> **Overview**
> **Mount** and **Umount** no longer abort the whole batch when one repository fails: each repo is handled in a `try`/`except` that logs the failure via `self.app.LOG.exception` and continues with the rest.
> 
> **`--restart` / `-r`** now runs only after a successful mount or umount (moved into the `else` branch), so a failed repo is not restarted.
> 
> Copyright year is bumped to 2026; `logging` is imported and **`Umount`** declares a module `logger` (errors still go through `self.app.LOG`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 052e7ef985df150c60765790f9b4b58b62e98338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->