### PR TITLE
resilient unmount

### DIFF
--- a/wazo_sdk/commands/mount.py
+++ b/wazo_sdk/commands/mount.py
@@ -37,10 +37,13 @@ class Mount(Command):
             try:
                 self.mounter.mount(repo)
             except Exception:
-                self.app.LOG.exception('Error unmount repo %s', repo)
+                self.app.LOG.exception('Error mount repo %s', repo)
             else:
                 if parsed_args.restart:
-                    self.service.restart(repo)
+                    try:
+                        self.service.restart(repo)
+                    except Exception:
+                        self.app.LOG.exception('Error restarting repo %s', repo)
 
         if parsed_args.list:
             mounted_repos = self.mounter.list_()
@@ -78,4 +81,7 @@ class Umount(Command):
                 self.app.LOG.exception('Error unmount repo %s', repo)
             else:
                 if parsed_args.restart:
-                    self.service.restart(repo)
+                    try:
+                        self.service.restart(repo)
+                    except Exception:
+                        self.app.LOG.exception('Error restarting repo %s', repo)


### PR DESCRIPTION
- **fix(umount): persist & log through per-repo umount error**
- **fix(mount,umount): also log & continue on restart errors**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI error-handling and logging only; no change to mount/umount or restart semantics on success paths.
> 
> **Overview**
> Makes **mount** and **umount** batch operations more resilient when `--restart` is used.
> 
> After a successful mount or umount, **service restart** is now wrapped in its own `try/except`: a restart failure is logged (`Error restarting repo %s`) and processing continues for the remaining repos instead of aborting the command.
> 
> Also fixes a copy-paste bug in the **mount** failure log message so it says **mount** instead of **unmount**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eac131dee2a22981dbe01714e73777800447038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->