### PR TITLE
add-provd-wait

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -211,6 +211,8 @@ wazo-provd:
     usr/bin/dhcpd-update: /usr/sbin/dhcpd-update
   log_filename: /var/log/wazo-provd.log
   service: wazo-provd
+  clean:
+    - /usr/local/bin/wazo-provd-wait
 
 wazo-provd-cli:
   python3: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line packaging change with no runtime, auth, or data-path impact.
> 
> **Overview**
> Registers **`wazo-provd-wait`** on the **`wazo-provd`** package in **`project.yml`**, adding **`/usr/local/bin/wazo-provd-wait`** to that component’s **`clean`** list so the wait helper is handled like other Wazo service binaries (e.g. **`wazo-auth-wait`**, **`wazo-confd-wait`**).
> 
> This is packaging metadata only; it wires provd into the same install/cleanup pattern used for startup coordination helpers across the stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa9a1cb9d05c6e35611ce1e892001c76b7e2cc7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->